### PR TITLE
Using official nginx container for the proxy service.

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -4,5 +4,5 @@ NAME=snappy-jenkins
 PROXY_NAME=snappy-proxy
 JENKINS_CONTAINER_NAME="fgimenez/$NAME"
 JENKINS_CONTAINER_INIT_COMMAND="sudo docker run -p 8080:8080 -d -v $JENKINS_HOME:/var/jenkins_home --restart always --name $NAME -t $JENKINS_CONTAINER_NAME"
-PROXY_CONTAINER_NAME="jwilder/nginx-proxy"
+PROXY_CONTAINER_NAME="nginx"
 PROXY_CONTAINER_INIT_COMMAND="sudo docker run -d -p 8081:80 --link $NAME:$NAME --restart always -v $JENKINS_HOME/proxy.conf:/etc/nginx/conf.d/proxy.conf:ro -v /var/run/docker.sock:/tmp/docker.sock:ro --name $PROXY_NAME $PROXY_CONTAINER_NAME"


### PR DESCRIPTION
Since we are copying the proxy config at build time and we are linking
to the jenkins container there's no need for a specialized nginx version