### PR TITLE
Using /dev/vdb for $JENKINS_HOME; increased executions and days to keep in the github job

### DIFF
--- a/bin/cloud-provision.sh
+++ b/bin/cloud-provision.sh
@@ -10,7 +10,7 @@ then
     echo "No snappy product integration credentials path given as second argument, won't be able to connect to SPI"
 fi
 
-JENKINS_HOME=/home/ubuntu/jenkins
+JENKINS_HOME=/mnt/jenkins
 
 . ./bin/common.sh
 . ./bin/cloud-common.sh
@@ -52,8 +52,8 @@ launch_instance(){
 }
 
 send_and_execute(){
-    scp ./bin/remote/provision.sh ubuntu@$INSTANCE_IP:/home/ubuntu
-    execute_remote_command "sh /home/ubuntu/provision.sh"
+    scp ./bin/remote/provision.sh ubuntu@$INSTANCE_IP:$JENKINS_HOME
+    execute_remote_command "sh $JENKINS_HOME/provision.sh"
 }
 
 copy_credentials() {
@@ -73,7 +73,7 @@ copy_ghprb_conf(){
 }
 
 setup_jenkins_home(){
-    execute_remote_command "rm -rf $JENKINS_HOME && mkdir -p $JENKINS_HOME && chmod a+w $JENKINS_HOME"
+    execute_remote_command "sudo umount /mnt && sudo rm -rf $JENKINS_HOME && sudo mkdir -p $JENKINS_HOME && sudo mount /dev/vdb $JENKINS_HOME && sudo chmod a+rwx $JENKINS_HOME"
 }
 
 create_security_group

--- a/bin/cloud-redeploy.sh
+++ b/bin/cloud-redeploy.sh
@@ -9,13 +9,12 @@ then
 fi
 
 INSTANCE_IP=$1
-BACKUP_FOLDER="/home/ubuntu/jenkins_backup"
 
 . ./bin/cloud-common.sh
 
 send_and_execute(){
-    scp ./bin/remote/redeploy.sh ubuntu@$INSTANCE_IP:/home/ubuntu
-    execute_remote_command ". /home/ubuntu/redeploy.sh"
+    scp ./bin/remote/redeploy.sh ubuntu@$INSTANCE_IP:$JENKINS_HOME
+    execute_remote_command ". $JENKINS_HOME/redeploy.sh"
 }
 
 send_and_execute

--- a/bin/remote/redeploy.sh
+++ b/bin/remote/redeploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-BACKUP_FOLDER="/home/ubuntu/jenkins_backup"
+BACKUP_FOLDER="/mnt/jenkins_backup"
 
 remove_container(){
     CONTAINER_NAME=$1
@@ -13,6 +13,7 @@ remove_backup(){
 }
 
 create_backup(){
+    sudo mkdir -p $BACKUP_FOLDER && sudo chmod a+rwx $BACKUP_FOLDER
     cp -r $JENKINS_HOME $BACKUP_FOLDER
 }
 

--- a/config/jobs/github-snappy-integration-tests-cloud/config.xml
+++ b/config/jobs/github-snappy-integration-tests-cloud/config.xml
@@ -3,8 +3,8 @@
   <actions/>
   <description></description>
   <logRotator class="hudson.tasks.LogRotator">
-    <daysToKeep>1</daysToKeep>
-    <numToKeep>10</numToKeep>
+    <daysToKeep>2</daysToKeep>
+    <numToKeep>20</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>


### PR DESCRIPTION
The m1.large flavor used for the jenkins instance includes a 80gb ephemeral disk that we wasn't using, with this changes the $JENKINS_HOME dir is deployed in that disk.