### PR TITLE
Generic openstack credentials and xenial for host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,10 @@ RUN /usr/local/bin/plugins.sh /usr/share/jenkins/ref/active.txt
 # copy job definitions
 RUN mkdir /usr/share/jenkins/ref/job-definitions
 
-COPY config/jobs/snappy-daily-1504-canonistack/config.xml \
-  /usr/share/jenkins/ref/job-definitions/snappy-daily-1504-canonistack.xml
-COPY config/jobs/snappy-daily-rolling-canonistack/config.xml \
-  /usr/share/jenkins/ref/job-definitions/snappy-daily-rolling-canonistack.xml
+COPY config/jobs/snappy-daily-1504-openstack/config.xml \
+  /usr/share/jenkins/ref/job-definitions/snappy-daily-1504-openstack.xml
+COPY config/jobs/snappy-daily-rolling-openstack/config.xml \
+  /usr/share/jenkins/ref/job-definitions/snappy-daily-rolling-openstack.xml
 COPY config/jobs/snappy-daily-rolling-bbb/config.xml \
   /usr/share/jenkins/ref/job-definitions/snappy-daily-rolling-bbb.xml
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ You can setup the enviroment locally by executing this command:
 
     $ ./bin/local-provision <cloud_credentials_path>
 
-The ```<cloud_credentials_path>``` required by the command indicates a path to the OpenStack credentials that will be used by the Jenkins instance to spin up Snappy instances. It requires a novarc file and a user key file in that directory, the scripts copies them to the Jenkins container and the jobs use them to access to the cloud provider API.
+The ```<cloud_credentials_path>``` required by the command indicates a path to a novarc file with the OpenStack credentials that will be used by the Jenkins instance to spin up Snappy instances. The scripts copies it to the Jenkins container and the jobs use it to access to the cloud provider API.
 
 Once the scripts finish you can access the jenkins instance from the browser at ```http://localhost:8080```
 
 ### Cloud provision
 
-There are additional requirements for the cloud provision besides having loaded Openstack credentials. In this case the setup is done in a cloud instance and you should be able to spin it up. The needed packages can be installed in Ubuntu with:
+There are additional requirements for the cloud provision besides having loaded OpenStack credentials. In this case the setup is done in a cloud instance and you should be able to spin it up. The needed packages can be installed in Ubuntu with:
 
     $ sudo apt-get install cloud-utils python-novaclient
 
@@ -34,7 +34,7 @@ To setup the CI instance in the cloud just execute:
 
     $ ./bin/cloud-provision.sh <cloud_credentials_path>
 
-This command creates a new VM with two containers in it, as described in this image:
+being, as in the local case, `<cloud_credentials_path>` the location of an OpeStack novarc file. This command creates a new VM with two containers in it, as described in this image:
 
 ![Block Diagram](/img/snappy-jenkins.png?raw=true)
 

--- a/bin/cloud-provision.sh
+++ b/bin/cloud-provision.sh
@@ -15,11 +15,11 @@ JENKINS_HOME=/mnt/jenkins
 . ./bin/common.sh
 . ./bin/cloud-common.sh
 
-OPENSTACK_CREDENTIALS_PATH=$1
+NOVARC_PATH=$1
 SPI_CREDENTIALS_PATH=$2
 SECGROUP=$NAME
 FLAVOR=m1.large
-REMOTE_CREDENTIALS_DIR="$JENKINS_HOME/.openstack"
+OPENSTACK_CREDENTIALS_DIR="$JENKINS_HOME/.openstack"
 
 create_security_group() {
     nova secgroup-delete $SECGROUP
@@ -58,10 +58,8 @@ send_and_execute(){
 }
 
 copy_credentials() {
-    # first novarc file in $OPENSTACK_CREDENTIALS_PATH
-    first_novarc=$(ls $OPENSTACK_CREDENTIALS_PATH/novarc* | sort -d | head -1)
+    scp $NOVARC_PATH ubuntu@$INSTANCE_IP:$OPENSTACK_CREDENTIALS_DIR/novarc
 
-    scp $first_novarc ubuntu@$INSTANCE_IP:$REMOTE_CREDENTIALS_DIR/novarc
     if [ ! -z "$SPI_CREDENTIALS_PATH" ]
     then
         scp $SPI_CREDENTIALS_PATH ubuntu@$INSTANCE_IP:$JENKINS_HOME/.spi.ini
@@ -82,7 +80,7 @@ sudo rm -rf $JENKINS_HOME && \
 sudo mkdir -p $JENKINS_HOME && \
 sudo mount /dev/vdb $JENKINS_HOME && \
 sudo chmod a+rwx $JENKINS_HOME && \
-mkdir -p $REMOTE_CREDENTIALS_DIR"
+mkdir -p $OPENSTACK_CREDENTIALS_DIR"
 }
 
 create_security_group

--- a/bin/cloud-provision.sh
+++ b/bin/cloud-provision.sh
@@ -19,6 +19,7 @@ OPENSTACK_CREDENTIALS_PATH=$1
 SPI_CREDENTIALS_PATH=$2
 SECGROUP=$NAME
 FLAVOR=m1.large
+REMOTE_CREDENTIALS_DIR="$JENKINS_HOME/.openstack"
 
 create_security_group() {
     nova secgroup-delete $SECGROUP
@@ -31,7 +32,7 @@ create_security_group() {
 }
 
 launch_instance(){
-    IMAGE_ID=$(nova image-list | grep wily-daily-amd64 | head -1 | awk '{print $4}')
+    IMAGE_ID=$(nova image-list | grep xenial-daily-amd64 | head -1 | awk '{print $4}')
 
     INSTANCE_ID=$(nova boot --key-name ${OS_USERNAME}_${OS_REGION_NAME} --security-groups $SECGROUP --flavor $FLAVOR --image $IMAGE_ID $NAME --poll | grep '| id ' | awk '{print $4}')
 
@@ -57,7 +58,10 @@ send_and_execute(){
 }
 
 copy_credentials() {
-    scp -r $OPENSTACK_CREDENTIALS_PATH ubuntu@$INSTANCE_IP:$JENKINS_HOME
+    # first novarc file in $OPENSTACK_CREDENTIALS_PATH
+    first_novarc=$(ls $OPENSTACK_CREDENTIALS_PATH/novarc* | sort -d | head -1)
+
+    scp $first_novarc ubuntu@$INSTANCE_IP:$REMOTE_CREDENTIALS_DIR/novarc
     if [ ! -z "$SPI_CREDENTIALS_PATH" ]
     then
         scp $SPI_CREDENTIALS_PATH ubuntu@$INSTANCE_IP:$JENKINS_HOME/.spi.ini
@@ -69,11 +73,16 @@ copy_proxy_conf(){
 }
 
 copy_ghprb_conf(){
-    scp ./config/ghprb/org.jenkinsci.plugins.ghprb.GhprbTrigger.xml ubuntu@$INSTANCE_IP:$JENKINS_HOME
+    scp ./config/ghprb/$GHPRB_CONFIG_FILE ubuntu@$INSTANCE_IP:$JENKINS_HOME
 }
 
 setup_jenkins_home(){
-    execute_remote_command "sudo umount /mnt && sudo rm -rf $JENKINS_HOME && sudo mkdir -p $JENKINS_HOME && sudo mount /dev/vdb $JENKINS_HOME && sudo chmod a+rwx $JENKINS_HOME"
+    execute_remote_command "sudo umount /mnt && \
+sudo rm -rf $JENKINS_HOME && \
+sudo mkdir -p $JENKINS_HOME && \
+sudo mount /dev/vdb $JENKINS_HOME && \
+sudo chmod a+rwx $JENKINS_HOME && \
+mkdir -p $REMOTE_CREDENTIALS_DIR"
 }
 
 create_security_group

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -6,3 +6,5 @@ JENKINS_CONTAINER_NAME="fgimenez/$NAME"
 JENKINS_CONTAINER_INIT_COMMAND="sudo docker run -p 8080:8080 -d -v $JENKINS_HOME:/var/jenkins_home --privileged=true --restart always --name $NAME -t $JENKINS_CONTAINER_NAME"
 PROXY_CONTAINER_NAME="nginx"
 PROXY_CONTAINER_INIT_COMMAND="sudo docker run -d -p 8081:80 --link $NAME:$NAME --restart always -v $JENKINS_HOME/proxy.conf:/etc/nginx/conf.d/proxy.conf:ro -v /var/run/docker.sock:/tmp/docker.sock:ro --name $PROXY_NAME $PROXY_CONTAINER_NAME"
+
+GHPRB_CONFIG_FILE="org.jenkinsci.plugins.ghprb.GhprbTrigger.xml"

--- a/config/jobs/create-cloud-image/config.xml
+++ b/config/jobs/create-cloud-image/config.xml
@@ -38,7 +38,7 @@
   <builders>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
-. $HOME/.canonistack/novarc
+. $HOME/.openstack/novarc
 snappy-cloud-image -loglevel debug -release $release -channel $channel -action create</command>
     </hudson.tasks.Shell>
   </builders>

--- a/config/jobs/delete-cloud-image/config.xml
+++ b/config/jobs/delete-cloud-image/config.xml
@@ -38,7 +38,7 @@
   <builders>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
-. $HOME/.canonistack/novarc
+. $HOME/.openstack/novarc
 
 openstack image delete ubuntu-core/custom/ubuntu-${release}-snappy-core-amd64-${channel}-${version}-disk1.img</command>
     </hudson.tasks.Shell>

--- a/config/jobs/github-snappy-integration-tests-cloud/config.xml
+++ b/config/jobs/github-snappy-integration-tests-cloud/config.xml
@@ -96,7 +96,7 @@ zyga
   <builders>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
-. $HOME/.canonistack/novarc
+. $HOME/.openstack/novarc
 
 snappy-tests-job -repo $ghprbAuthorRepoGitUrl -src $ghprbSourceBranch -release rolling -channel edge -snappy-from-branch -output-dir $PWD/$BUILD_TAG
 

--- a/config/jobs/snappy-cloud-test/config.xml
+++ b/config/jobs/snappy-cloud-test/config.xml
@@ -39,7 +39,7 @@
   <builders>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
-. $HOME/.canonistack/novarc
+. $HOME/.openstack/novarc
 
 snappy-tests-job -release $release -channel $channel -output-dir $PWD/$BUILD_TAG
 

--- a/config/jobs/snappy-daily-1504-openstack/config.xml
+++ b/config/jobs/snappy-daily-1504-openstack/config.xml
@@ -25,7 +25,7 @@
   <builders>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
-. $HOME/.canonistack/novarc
+. $HOME/.openstack/novarc
 
 snappy-tests-job -release 1504 -channel edge -output-dir $PWD/$BUILD_TAG
 

--- a/config/jobs/snappy-daily-rolling-openstack/config.xml
+++ b/config/jobs/snappy-daily-rolling-openstack/config.xml
@@ -29,7 +29,7 @@
   <builders>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
-. $HOME/.canonistack/novarc
+. $HOME/.openstack/novarc
 
 snappy-tests-job -release rolling -channel edge -output-dir $PWD/$BUILD_TAG
 


### PR DESCRIPTION
With these changes the cloud provider credentials are always stored in $HOME/.openstack.

Also, the only novarc file sent to the server being provisioned is the first one found in the credentials directory (sorted alphabetically), and that's actually all that is sent in terms of openstack credentials, we don't need any keys now that the images are created with udf

The jobs config files are updated accordingly too.

The image used for the server is also updated from wily to xenial