### PR TITLE
Updated ssh config; added image purge call

### DIFF
--- a/bin/remote/provision.sh
+++ b/bin/remote/provision.sh
@@ -9,22 +9,11 @@ setup_ssh(){
     mkdir -p $JENKINS_HOME/.ssh && ssh-keygen -q -t rsa -N '' -f $JENKINS_HOME/.ssh/id_rsa
 
     cat <<EOT >> $JENKINS_HOME/.ssh/config
-Host 10.55.32.* 10.55.33.* 10.55.34.* 10.55.35.* 10.55.36.* 10.55.37.* 10.55.38.* 10.55.39.* 10.55.40.* 10.55.41.* 10.55.42.* 10.55.43.* 10.55.44.* 10.55.45.* 10.55.46.* 10.55.47.* 10.55.60.* 10.55.61.* *.canonistack
+Host 10.55.32.* 10.55.33.* 10.55.34.* 10.55.35.* 10.55.36.* 10.55.37.* 10.55.38.* 10.55.39.* 10.55.40.* 10.55.41.* 10.55.42.* 10.55.43.* 10.55.44.* 10.55.45.* 10.55.46.* 10.55.47.* 10.55.60.* 10.55.61.* *.canonistack 10.42.56.*
     User ubuntu
-    IdentityFile ~/.canonistack/${OS_USERNAME}_${OS_REGION_NAME}.key
     ProxyCommand None
     StrictHostKeyChecking no
     UserKnownHostsFile=/dev/null
-
-Host server-*
-    User ubuntu
-    IdentityFile ~/.canonistack/${OS_USERNAME}_${OS_REGION_NAME}.key
-    ProxyCommand None
-    StrictHostKeyChecking no
-    UserKnownHostsFile=/dev/null
-
-Host *.cloudapp.net
-    IdentityFile ~/.ssh/azure.key
 EOT
 }
 
@@ -35,9 +24,16 @@ launch_container(){
     eval $CONTAINER_INIT_COMMAND
 }
 
+purge_images(){
+    # remove the images created with previous credentials, they won't be accessible
+    sudo docker exec -t $JENKINS_CONTAINER_NAME 'source ~/.openstack/novarc && snappy-cloud-image -action purge'
+}
+
 install_docker
 
 setup_ssh
 
 launch_container "$JENKINS_CONTAINER_NAME" "$JENKINS_CONTAINER_INIT_COMMAND"
 launch_container "$PROXY_CONTAINER_NAME" "$PROXY_CONTAINER_INIT_COMMAND"
+
+purge_images


### PR DESCRIPTION
The .ssh/config file now include a new provider IP range and doesn't copy the nova key, since the images created with udf using --developer-mode already carry the key of the creator user.

Because of that, as the final step in the provision process, the snappy-cloud-image purge action is invoked, once a new snappy-jenlins is deployed the instances from images created by the previous will no longer be accessible.