### PR TITLE
Copy the actual ssh keys to the location required by udf

### DIFF
--- a/bin/local-provision.sh
+++ b/bin/local-provision.sh
@@ -39,3 +39,5 @@ sudo docker stop $NAME $PROXY_NAME
 sudo docker rm -f $NAME $PROXY_NAME
 eval $JENKINS_CONTAINER_INIT_COMMAND
 eval $PROXY_CONTAINER_INIT_COMMAND
+
+sudo docker exec -t $NAME /var/jenkins_home/postStart.sh

--- a/bin/remote/provision.sh
+++ b/bin/remote/provision.sh
@@ -16,6 +16,11 @@ launch_container(){
     eval $CONTAINER_INIT_COMMAND
 }
 
+post_start_actions(){
+    local container_name=$1
+    sudo docker exec -t $container_name /var/jenkins_home/postStart.sh
+}
+
 purge_images(){
     # remove the images created with previous credentials, they won't be accessible
     sudo docker exec -t $JENKINS_CONTAINER_NAME 'source ~/.openstack/novarc && snappy-cloud-image -action purge'
@@ -27,5 +32,7 @@ setup_ssh
 
 launch_container "$JENKINS_CONTAINER_NAME" "$JENKINS_CONTAINER_INIT_COMMAND"
 launch_container "$PROXY_CONTAINER_NAME" "$PROXY_CONTAINER_INIT_COMMAND"
+
+post_start_actions "$NAME"
 
 purge_images

--- a/config/k8s/jenkins-master-rc.yaml
+++ b/config/k8s/jenkins-master-rc.yaml
@@ -36,6 +36,11 @@ spec:
             port: 8080
           initialDelaySeconds: 60
           timeoutSeconds: 5
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - "/var/jenkins_home/postStart.sh"
       volumes:
       - name: jenkins-master-data
         emptyDir: {}

--- a/containers/jenkins-master/Dockerfile
+++ b/containers/jenkins-master/Dockerfile
@@ -79,3 +79,6 @@ COPY config/ghprb/org.jenkinsci.plugins.ghprb.GhprbTrigger.xml \
 # ssh config
 RUN mkdir -p /usr/share/jenkins/ref/.ssh
 COPY config/ssh /usr/share/jenkins/ref/.ssh/config
+
+# postStart script
+COPY config/scripts/postStart.sh /usr/share/jenkins/ref/postStart.sh

--- a/containers/jenkins-master/config/scripts/postStart.sh
+++ b/containers/jenkins-master/config/scripts/postStart.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+BASE=/var/jenkins_home
+cp $BASE/ssh-key/id-rsa $BASE/.ssh/id_rsa
+cp $BASE/ssh-key/id-rsa.pub $BASE/.ssh/id_rsa.pub


### PR DESCRIPTION
For compatibility with Kubernetes the ssh keys for accessing the snappy instances are stored under `$JENKINS_HOME/ssh-keys` (where the k8s secret is mounted) and named `id-rsa` and `id-rsa.pub`. UDF requires the keys to be placed in `.ssh/id_rsa`. 

The changes in this PR copy the keypair into the required path after the container is up, the script for doing so is the same for both k8s (we use the lifecycle postStart hook here) and the current local and cloud provision scripts