### PR TITLE
Fix docker graph directory location due to errors with aufs and symlinks

### DIFF
--- a/bin/cloud-common.sh
+++ b/bin/cloud-common.sh
@@ -20,6 +20,6 @@ wait_for_ssh(){
             echo "Timed out waiting for ssh. Aborting!"
             exit 1
         fi
-        sleep 5
+        sleep 10
     done
 }

--- a/bin/cloud-provision.sh
+++ b/bin/cloud-provision.sh
@@ -51,7 +51,7 @@ wait_for_ip(){
 
 
 launch_instance(){
-    IMAGE_ID=$(openstack image list | grep wily-daily-amd64 | head -1 | awk '{print $4}')
+    IMAGE_ID=$(openstack image list | grep "$DIST"-daily-amd64 | head -1 | awk '{print $4}')
 
     INSTANCE_ID=$(openstack server create --key-name ${OS_USERNAME}_${OS_REGION_NAME} --security-group $SECGROUP --flavor $FLAVOR --image $IMAGE_ID $NAME | grep '| id ' | awk '{print $4}')
 

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+DIST="trusty"
+
 NAME=jenkins-master-service
 PROXY_NAME=snappy-proxy
 JENKINS_CONTAINER_NAME=fgimenez/snappy-jenkins

--- a/bin/remote/provision.sh
+++ b/bin/remote/provision.sh
@@ -4,13 +4,15 @@ set -x
 install_docker(){
     # install latest version of docker according to https://docs.docker.com/engine/installation/ubuntulinux/
     sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-    echo "deb https://apt.dockerproject.org/repo ubuntu-wily main" | sudo tee /etc/apt/sources.list.d/docker.list
+    echo "deb https://apt.dockerproject.org/repo ubuntu-$DIST main" | sudo tee /etc/apt/sources.list.d/docker.list
     sudo apt-get update
     sudo apt-get purge -y lxc-docker
     sudo apt-get install -y linux-image-extra-$(uname -r) docker-engine
+    sudo service docker stop
     # make docker write to /mnt (where the cloud instances mount the additional disk) to prevent
     # devicemapper to fill the base disk
-    sudo mv /var/lib/docker /mnt && sudo ln -s /mnt/docker /var/lib/docker
+    sudo mv /var/lib/docker /mnt
+    echo 'DOCKER_OPTS="-g /mnt/docker"' | sudo tee /etc/default/docker
     sudo service docker start
     sudo systemctl enable docker
 }
@@ -37,6 +39,7 @@ purge_images(){
     sudo docker exec -t $JENKINS_CONTAINER_NAME 'source ~/.openstack/novarc && snappy-cloud-image -action purge'
 }
 
+. $JENKINS_HOME/common.sh
 install_docker
 
 setup_ssh
@@ -46,5 +49,4 @@ launch_container "$PROXY_CONTAINER_NAME" "$PROXY_CONTAINER_INIT_COMMAND"
 
 purge_images
 
-. $JENKINS_HOME/common.sh
 create_slaves


### PR DESCRIPTION
Also:
* Increased timeout between ssh retries
* The distribution is now a variable
* Switched to trusty because of errors with linux-image-extra from wily archive