### PR TITLE
Update the location to the ssh key in the slaves

### DIFF
--- a/containers/jenkins-slave-vivid/Dockerfile
+++ b/containers/jenkins-slave-vivid/Dockerfile
@@ -29,6 +29,7 @@ RUN echo "jenkins-slave ALL=NOPASSWD: ALL" >> /etc/sudoers
 # ssh config
 RUN mkdir -p /home/jenkins-slave/.ssh
 COPY config/ssh /home/jenkins-slave/.ssh/config
+RUN sed -i 's@ssh-key/id-rsa@.ssh/id_rsa@' ~/.ssh/config
 
 # postStart script
 COPY config/scripts/postStart.sh /home/jenkins-slave/postStart.sh

--- a/containers/jenkins-slave-vivid/Dockerfile
+++ b/containers/jenkins-slave-vivid/Dockerfile
@@ -30,6 +30,7 @@ RUN echo "jenkins-slave ALL=NOPASSWD: ALL" >> /etc/sudoers
 RUN mkdir -p /home/jenkins-slave/.ssh
 COPY config/ssh /home/jenkins-slave/.ssh/config
 RUN sed -i 's@ssh-key/id-rsa@.ssh/id_rsa@' /home/jenkins-slave/.ssh/config
+RUN chown -R jenkins-slave:jenkins-slave /home/jenkins-slave/.ssh
 
 # postStart script
 COPY config/scripts/postStart.sh /home/jenkins-slave/postStart.sh

--- a/containers/jenkins-slave-vivid/Dockerfile
+++ b/containers/jenkins-slave-vivid/Dockerfile
@@ -29,7 +29,7 @@ RUN echo "jenkins-slave ALL=NOPASSWD: ALL" >> /etc/sudoers
 # ssh config
 RUN mkdir -p /home/jenkins-slave/.ssh
 COPY config/ssh /home/jenkins-slave/.ssh/config
-RUN sed -i 's@ssh-key/id-rsa@.ssh/id_rsa@' ~/.ssh/config
+RUN sed -i 's@ssh-key/id-rsa@.ssh/id_rsa@' /home/jenkins-slave/.ssh/config
 
 # postStart script
 COPY config/scripts/postStart.sh /home/jenkins-slave/postStart.sh

--- a/containers/jenkins-slave-xenial/Dockerfile
+++ b/containers/jenkins-slave-xenial/Dockerfile
@@ -38,6 +38,7 @@ RUN echo "jenkins-slave ALL=NOPASSWD: ALL" >> /etc/sudoers
 RUN mkdir -p /home/jenkins-slave/.ssh
 COPY config/ssh /home/jenkins-slave/.ssh/config
 RUN sed -i 's@ssh-key/id-rsa@.ssh/id_rsa@' /home/jenkins-slave/.ssh/config
+RUN chown -R jenkins-slave:jenkins-slave /home/jenkins-slave/.ssh
 
 # postStart script
 COPY config/scripts/postStart.sh /home/jenkins-slave/postStart.sh

--- a/containers/jenkins-slave-xenial/Dockerfile
+++ b/containers/jenkins-slave-xenial/Dockerfile
@@ -37,6 +37,7 @@ RUN echo "jenkins-slave ALL=NOPASSWD: ALL" >> /etc/sudoers
 # ssh config
 RUN mkdir -p /home/jenkins-slave/.ssh
 COPY config/ssh /home/jenkins-slave/.ssh/config
+RUN sed -i 's@ssh-key/id-rsa@.ssh/id_rsa@' ~/.ssh/config
 
 # postStart script
 COPY config/scripts/postStart.sh /home/jenkins-slave/postStart.sh

--- a/containers/jenkins-slave-xenial/Dockerfile
+++ b/containers/jenkins-slave-xenial/Dockerfile
@@ -37,7 +37,7 @@ RUN echo "jenkins-slave ALL=NOPASSWD: ALL" >> /etc/sudoers
 # ssh config
 RUN mkdir -p /home/jenkins-slave/.ssh
 COPY config/ssh /home/jenkins-slave/.ssh/config
-RUN sed -i 's@ssh-key/id-rsa@.ssh/id_rsa@' ~/.ssh/config
+RUN sed -i 's@ssh-key/id-rsa@.ssh/id_rsa@' /home/jenkins-slave/.ssh/config
 
 # postStart script
 COPY config/scripts/postStart.sh /home/jenkins-slave/postStart.sh


### PR DESCRIPTION
When we copy the ssh config from the master to the slaves, it comes from
a non-standard path with a non-standard name.