### PR TITLE
Set roam to false to the jobs with slave requirements.

### DIFF
--- a/containers/jenkins-master/config/jobs/create-cloud-image-all-snaps/config.xml
+++ b/containers/jenkins-master/config/jobs/create-cloud-image-all-snaps/config.xml
@@ -30,7 +30,7 @@
   </properties>
   <scm class="hudson.scm.NullSCM"/>
   <assignedNode>xenial</assignedNode>
-  <canRoam>true</canRoam>
+  <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>

--- a/containers/jenkins-master/config/jobs/create-cloud-image-vivid/config.xml
+++ b/containers/jenkins-master/config/jobs/create-cloud-image-vivid/config.xml
@@ -30,7 +30,7 @@
   </properties>
   <scm class="hudson.scm.NullSCM"/>
   <assignedNode>vivid</assignedNode>
-  <canRoam>true</canRoam>
+  <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>

--- a/containers/jenkins-master/config/jobs/github-snapcraft-integration-tests-cloud/config.xml
+++ b/containers/jenkins-master/config/jobs/github-snapcraft-integration-tests-cloud/config.xml
@@ -36,7 +36,7 @@
     <extensions/>
   </scm>
   <assignedNode>xenial</assignedNode>
-  <canRoam>true</canRoam>
+  <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>


### PR DESCRIPTION
<canRoam>true</canRoam> --- use any nodes
<canRoam>false</canRoam> --- use defined nodes/labels only
