### PR TITLE
Several fixes to the sync process.

### DIFF
--- a/bin/cloud-common.sh
+++ b/bin/cloud-common.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-JENKINS_HOME=/mnt/jenkins
+JENKINS_HOME=/home/ubuntu/jenkins
 
 execute_remote_command(){
     ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@$INSTANCE_IP 'export JENKINS_HOME='"'$JENKINS_HOME'"'; \

--- a/bin/cloud-provision.sh
+++ b/bin/cloud-provision.sh
@@ -16,7 +16,7 @@ fi
 NOVARC_PATH=$1
 SPI_CREDENTIALS_PATH=$2
 SECGROUP=$NAME
-FLAVOR=m1.large
+FLAVOR=cpu8-ram10-disk100-ephemeral20
 OPENSTACK_CREDENTIALS_DIR="$JENKINS_HOME/.openstack"
 
 create_security_group() {


### PR DESCRIPTION
* Do not use ephemeral disk for docker graph dir and jenkins home: with the usage
of instance snapshots we were missing the data stored in that disks when a new
instance was created from the snapshots. We use flavor with a bigger root disk to
store all the data

* Added code to sync openstack credentials

* Do not sync job config, this should be stored in the VCS

* Create the base ssh dir if missing