### PR TITLE
Remove the lowperformance build tag

### DIFF
--- a/containers/jenkins-master/config/jobs/github-snappy-integration-tests-cloud/config.xml
+++ b/containers/jenkins-master/config/jobs/github-snappy-integration-tests-cloud/config.xml
@@ -113,7 +113,7 @@ ip=$(tail -n 1 instance.info | awk 'NF>1{print $NF}')
 
 trap "snappy-cloud-client kill -instance-id $id" EXIT
 
-go run ./integration-tests/main.go -ip $ip -snappy-from-branch -output-dir $WORKSPACE/$BUILD_TAG -test-build-tags=lowperformance
+go run ./integration-tests/main.go -ip $ip -snappy-from-branch -output-dir $WORKSPACE/$BUILD_TAG
 
 subunit2junitxml $WORKSPACE/$BUILD_TAG/output/artifacts/results.subunit -o $WORKSPACE/$BUILD_TAG/output/artifacts/results.xml
 </command>

--- a/containers/jenkins-master/config/jobs/snappy-daily-1504-openstack/config.xml
+++ b/containers/jenkins-master/config/jobs/snappy-daily-1504-openstack/config.xml
@@ -77,7 +77,7 @@ ip=$(tail -n 1 instance.info | awk 'NF>1{print $NF}')
 
 trap "snappy-cloud-client kill -instance-id $id" EXIT
 
-go run ./integration-tests/main.go -ip $ip -output-dir $WORKSPACE/$BUILD_TAG -test-build-tags=lowperformance
+go run ./integration-tests/main.go -ip $ip -output-dir $WORKSPACE/$BUILD_TAG
 
 subunit2junitxml $WORKSPACE/$BUILD_TAG/output/artifacts/results.subunit -o $WORKSPACE/$BUILD_TAG/output/artifacts/results.xml
 </command>

--- a/containers/jenkins-master/config/jobs/snappy-daily-1504-update-openstack/config.xml
+++ b/containers/jenkins-master/config/jobs/snappy-daily-1504-update-openstack/config.xml
@@ -77,7 +77,7 @@ ip=$(tail -n 1 instance.info | awk 'NF>1{print $NF}')
 
 trap "snappy-cloud-client kill -instance-id $id" EXIT
 
-go run ./integration-tests/main.go -ip $ip -update -output-dir $WORKSPACE/$BUILD_TAG -test-build-tags=lowperformance
+go run ./integration-tests/main.go -ip $ip -update -output-dir $WORKSPACE/$BUILD_TAG
 
 subunit2junitxml $WORKSPACE/$BUILD_TAG/output/artifacts/results.subunit -o $WORKSPACE/$BUILD_TAG/output/artifacts/results.xml
 </command>

--- a/containers/jenkins-master/config/jobs/snappy-daily-rolling-openstack/config.xml
+++ b/containers/jenkins-master/config/jobs/snappy-daily-rolling-openstack/config.xml
@@ -76,7 +76,7 @@ ip=$(tail -n 1 instance.info | awk 'NF>1{print $NF}')
 
 trap "snappy-cloud-client kill -instance-id $id" EXIT
 
-go run ./integration-tests/main.go -ip $ip -output-dir $WORKSPACE/$BUILD_TAG -test-build-tags=lowperformance
+go run ./integration-tests/main.go -ip $ip -output-dir $WORKSPACE/$BUILD_TAG
 
 subunit2junitxml $WORKSPACE/$BUILD_TAG/output/artifacts/results.subunit -o $WORKSPACE/$BUILD_TAG/output/artifacts/results.xml
       </command>

--- a/containers/jenkins-master/config/jobs/snappy-daily-rolling-update-openstack/config.xml
+++ b/containers/jenkins-master/config/jobs/snappy-daily-rolling-update-openstack/config.xml
@@ -77,7 +77,7 @@ ip=$(tail -n 1 instance.info | awk 'NF>1{print $NF}')
 
 trap "snappy-cloud-client kill -instance-id $id" EXIT
 
-go run ./integration-tests/main.go -ip $ip -update -output-dir $WORKSPACE/$BUILD_TAG -test-build-tags=lowperformance
+go run ./integration-tests/main.go -ip $ip -update -output-dir $WORKSPACE/$BUILD_TAG
 
 subunit2junitxml $WORKSPACE/$BUILD_TAG/output/artifacts/results.subunit -o $WORKSPACE/$BUILD_TAG/output/artifacts/results.xml
 </command>


### PR DESCRIPTION
We don't have anymore performance issues with the scalingstack instances,
but were using this tag to prevent the execution of the Ubuntu Fan suite,
which was flaky in low performance machines and now was failing because
of a restrictive firewall that prevented the suite from connecting to
Docker Hub. Now we have an additional problem,
https://bugs.launchpad.net/snappy/+bug/1544507, and the tests have been
skipped, so no need to keep the build tag.