### PR TITLE
Added rolling/edge build triggers for urls describing the status of the os, kernel and gadget snap in the store

### DIFF
--- a/containers/jenkins-master/config/jobs/create-cloud-image-rolling-edge/config.xml
+++ b/containers/jenkins-master/config/jobs/create-cloud-image-rolling-edge/config.xml
@@ -25,7 +25,33 @@
       <spec>H/30 * * * *</spec>
       <entries>
         <org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
-          <url>http://system-image.ubuntu.com/ubuntu-core/rolling/edge/generic_amd64/index.json</url>
+          <url><![CDATA[https://search.apps.ubuntu.com/api/v1/search?q=architecture:amd64,name:ubuntu-core.canonical,channel:edge&size=1]]></url>
+          <proxyActivated>false</proxyActivated>
+          <checkStatus>false</checkStatus>
+          <statusCode>200</statusCode>
+          <timeout>300</timeout>
+          <checkETag>false</checkETag>
+          <checkLastModificationDate>false</checkLastModificationDate>
+          <inspectingContent>true</inspectingContent>
+          <contentTypes>
+            <org.jenkinsci.plugins.urltrigger.content.SimpleContentType/>
+          </contentTypes>
+        </org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+        <org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+          <url><![CDATA[https://search.apps.ubuntu.com/api/v1/search?q=architecture:amd64,name:canonical-pc-linux.canonical,channel:edge&size=1]]></url>
+          <proxyActivated>false</proxyActivated>
+          <checkStatus>false</checkStatus>
+          <statusCode>200</statusCode>
+          <timeout>300</timeout>
+          <checkETag>false</checkETag>
+          <checkLastModificationDate>false</checkLastModificationDate>
+          <inspectingContent>true</inspectingContent>
+          <contentTypes>
+            <org.jenkinsci.plugins.urltrigger.content.SimpleContentType/>
+          </contentTypes>
+        </org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+        <org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+          <url><![CDATA[https://search.apps.ubuntu.com/api/v1/search?q=architecture:all,name:canonical-pc.canonical,channel:edge&size=1]]></url>
           <proxyActivated>false</proxyActivated>
           <checkStatus>false</checkStatus>
           <statusCode>200</statusCode>


### PR DESCRIPTION
This requires the latest version of snappy-cloud-image which builds without asking system-image for the latest version available. 

With these changes we delegate the decision of building a new image to the url checks, snappy-cloud-image will create always an image putting a timestamp instead of the old image version numbers.