### PR TITLE
call docker-compose pull before docker-compose down

### DIFF
--- a/bin/cloud-redeploy.sh
+++ b/bin/cloud-redeploy.sh
@@ -6,6 +6,6 @@ set -x
 . ./bin/cloud-common.sh
 
 eval $(docker-machine env "$NAME_REMOTE")
-docker-compose -f ./config/compose/cluster.yml down
 docker-compose -f ./config/compose/cluster.yml pull
+docker-compose -f ./config/compose/cluster.yml down
 docker-compose -f ./config/compose/cluster.yml up -d


### PR DESCRIPTION
In order to improve the uptime of the services we can pull the new images before restarting them.