### PR TITLE
Check changes in the store by using the proper queries

### DIFF
--- a/containers/jenkins-master/Dockerfile
+++ b/containers/jenkins-master/Dockerfile
@@ -46,6 +46,9 @@ COPY config/jobs/create-cloud-image-1504-stable/config.xml \
 COPY config/jobs/create-cloud-image-rolling-edge/config.xml \
   /usr/share/jenkins/ref/job-definitions/create-cloud-image-rolling-edge.xml
 
+COPY config/jobs/check-snap-from-store/config.xml \
+  /usr/share/jenkins/ref/job-definitions/check-snap-from-store.xml
+
 COPY config/jobs/delete-cloud-image/config.xml \
   /usr/share/jenkins/ref/job-definitions/delete-cloud-image.xml
 

--- a/containers/jenkins-master/config/jobs/check-snap-from-store/config.xml
+++ b/containers/jenkins-master/config/jobs/check-snap-from-store/config.xml
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <logRotator class="hudson.tasks.LogRotator">
+    <daysToKeep>2</daysToKeep>
+    <numToKeep>20</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>snap</name>
+          <description></description>
+          <defaultValue>ubuntu-core.canonical</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>arch</name>
+          <description></description>
+          <defaultValue>amd64</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>channel</name>
+          <description></description>
+          <defaultValue>edge</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>vivid</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>true</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>previous_version=""
+previous_version_path=${WORKSPACE}/${snap}/${arch}/${channel}
+previous_version_file=${previous_version_path}/version
+
+echo "Snap: ${snap}, Arch: ${arch}, Channel: ${channel}"
+
+if [ -f ${previous_version_file} ]; then
+    previous_version=$(cat ${previous_version_file})
+    echo "Previous version found: ${previous_version}"
+else
+    echo "No previous version found, creating ${previous_version_path}"
+    mkdir -p ${previous_version_path}
+fi
+
+target_url=https://search.apps.ubuntu.com/api/v1/package/${snap}/${channel}
+current_version=$(curl -H "X-Ubuntu-Architecture: ${arch}" -H "Accept: application/hal+json" "${target_url}" | \
+      python -c 'import sys, json; print json.load(sys.stdin)["version"]')
+
+echo "Store version: $current_version"
+echo "$current_version" > "$previous_version_file"
+
+if [ "$current_version" != "$previous_version" ]; then
+    echo "New version found!"
+    return_value=0
+else
+    echo "No new version found"
+    return_value=1
+fi
+
+exit ${return_value}
+</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/containers/jenkins-master/config/jobs/create-cloud-image-rolling-edge/config.xml
+++ b/containers/jenkins-master/config/jobs/create-cloud-image-rolling-edge/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<project>
+<com.cloudbees.plugins.flow.BuildFlow plugin="build-flow-plugin@0.18">
   <actions/>
   <description></description>
   <logRotator class="hudson.tasks.LogRotator">
@@ -16,76 +16,43 @@
     </com.sonyericsson.rebuild.RebuildSettings>
   </properties>
   <scm class="hudson.scm.NullSCM"/>
-  <canRoam>true</canRoam>
+  <assignedNode>vivid</assignedNode>
+  <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>
-    <org.jenkinsci.plugins.urltrigger.URLTrigger plugin="urltrigger@0.41">
-      <spec>H/30 * * * *</spec>
-      <entries>
-        <org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
-          <url><![CDATA[https://search.apps.ubuntu.com/api/v1/search?q=architecture:amd64,name:ubuntu-core.canonical,channel:edge&size=1]]></url>
-          <proxyActivated>false</proxyActivated>
-          <checkStatus>false</checkStatus>
-          <statusCode>200</statusCode>
-          <timeout>300</timeout>
-          <checkETag>false</checkETag>
-          <checkLastModificationDate>false</checkLastModificationDate>
-          <inspectingContent>true</inspectingContent>
-          <contentTypes>
-            <org.jenkinsci.plugins.urltrigger.content.SimpleContentType/>
-          </contentTypes>
-        </org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
-        <org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
-          <url><![CDATA[https://search.apps.ubuntu.com/api/v1/search?q=architecture:amd64,name:canonical-pc-linux.canonical,channel:edge&size=1]]></url>
-          <proxyActivated>false</proxyActivated>
-          <checkStatus>false</checkStatus>
-          <statusCode>200</statusCode>
-          <timeout>300</timeout>
-          <checkETag>false</checkETag>
-          <checkLastModificationDate>false</checkLastModificationDate>
-          <inspectingContent>true</inspectingContent>
-          <contentTypes>
-            <org.jenkinsci.plugins.urltrigger.content.SimpleContentType/>
-          </contentTypes>
-        </org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
-        <org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
-          <url><![CDATA[https://search.apps.ubuntu.com/api/v1/search?q=architecture:all,name:canonical-pc.canonical,channel:edge&size=1]]></url>
-          <proxyActivated>false</proxyActivated>
-          <checkStatus>false</checkStatus>
-          <statusCode>200</statusCode>
-          <timeout>300</timeout>
-          <checkETag>false</checkETag>
-          <checkLastModificationDate>false</checkLastModificationDate>
-          <inspectingContent>true</inspectingContent>
-          <contentTypes>
-            <org.jenkinsci.plugins.urltrigger.content.SimpleContentType/>
-          </contentTypes>
-        </org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
-      </entries>
-      <labelRestriction>false</labelRestriction>
-    </org.jenkinsci.plugins.urltrigger.URLTrigger>
+    <hudson.triggers.TimerTrigger>
+      <spec>H/15 * * * *</spec>
+    </hudson.triggers.TimerTrigger>
   </triggers>
   <concurrentBuild>false</concurrentBuild>
-  <builders>
-    <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@2.29">
-      <configs>
-        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
-          <configs>
-            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>release=rolling
-channel=edge</properties>
-            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-          </configs>
-          <projects>create-cloud-image-all-snaps</projects>
-          <condition>ALWAYS</condition>
-          <triggerWithNoParameters>false</triggerWithNoParameters>
-          <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
-        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
-      </configs>
-    </hudson.plugins.parameterizedtrigger.TriggerBuilder>
-  </builders>
+  <builders/>
   <publishers/>
   <buildWrappers/>
-</project>
+  <icon/>
+  <dsl>for (item in ["ubuntu-core.canonical", "canonical-pc.canonical", "canonical-pc-linux.canonical"]) {
+  ignore(FAILURE) {
+    b = build("check-snap-from-store", snap: item)
+  }
+  if (b.result.name == "SUCCESS") {
+    ignore(FAILURE) {
+      c = build("create-cloud-image-all-snaps", release: "rolling", channel: "edge", arch: "amd64")
+    }
+    if c.result.name == "FAILURE"{
+      out.println("Error creating image, reseting version file")
+      String filename = "/home/jenkins-slave/workspace/check-snap-from-store/${item}/amd64/edge/version"
+      boolean fileSuccessfullyDeleted =  new File(filename).delete()
+
+      if (fileSuccessfullyDeleted) {
+        out.println("File ${filename} deleted after error building image")
+      } else {
+        out.println("Error deleting ${filename} after error building image")
+      }
+    }
+    break;
+  }
+}
+</dsl>
+  <buildNeedsWorkspace>false</buildNeedsWorkspace>
+</com.cloudbees.plugins.flow.BuildFlow>

--- a/containers/jenkins-master/plugins/active.txt
+++ b/containers/jenkins-master/plugins/active.txt
@@ -1,5 +1,6 @@
 ant:1.2:pinned
 antisamy-markup-formatter:1.1:pinned
+build-flow-plugin:0.18:pinned
 cobertura:1.9.7:pinned
 credentials:1.24:pinned
 cvs:2.11:pinned


### PR DESCRIPTION
In order to have the correct results from the store we need to pass a http header in the request. With this changes there's a parameterized job that knows how to query the string for a snap-channel-arch combination and succeeds if there's a new version available. This job is used in a build flow to determine if the build job for the rolling/edge image should be triggered.

The persistence between executions of the check job is carried through files. For that reason the job is tied to the vivid instance, so that it is always executed in the same host. We should iterate on this.