### PR TITLE
jobs: do not run the snappy autopkgtests concurrecntly

### DIFF
--- a/containers/jenkins-master/config/jobs/github-snappy-autopkgtest-cloud/config.xml
+++ b/containers/jenkins-master/config/jobs/github-snappy-autopkgtest-cloud/config.xml
@@ -98,7 +98,7 @@ niemeyer
       </extensions>
     </org.jenkinsci.plugins.ghprb.GhprbTrigger>
   </triggers>
-  <concurrentBuild>true</concurrentBuild>
+  <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
       <command><![CDATA[


### PR DESCRIPTION
When many jobs of this are running in the same node, the unittests seem
to get stuck.