### PR TITLE
added support for binary secrets and fixed bot credentials restoration

### DIFF
--- a/bin/secrets/backup.sh
+++ b/bin/secrets/backup.sh
@@ -24,7 +24,7 @@ backup_dir(){
             if [ "$line" != "Keys" ]; then
                 local dir="$base_target_dir/$source_dir"
                 mkdir -p "$dir"
-                vault read -field=value "$source_dir$line" > "$dir/$line"
+                vault_read_to_file "$source_dir$line" "$dir/$line"
             fi
         fi
     done

--- a/bin/secrets/common.sh
+++ b/bin/secrets/common.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 setup_vault_addr(){
     machine_name=$1
@@ -14,18 +14,23 @@ vault_machine_name(){
     echo "vault-${environment}-${os_username}-${os_region_name}"
 }
 
-setup_vault_addr(){
-    machine_name=$1
+vault_read_to_file(){
+    local vault_path="$1"
+    local file_path="$2"
+    local value=$(vault read -field=value "$vault_path")
 
-    export VAULT_ADDR=http://$(docker-machine ip "$machine_name"):8200
+    if [ "$value" != "No value found at $vault_path" ]; then
+        echo -n "$value" | uudecode -o /dev/stdout > "$file_path"
+    else
+        echo ""
+    fi
 }
 
-vault_machine_name(){
-    environment=$1
-    os_username=${2:-${OS_USERNAME}}
-    os_region_name=${3:-${OS_REGION_NAME}}
+vault_write_from_file(){
+    local file_path="$1"
+    local vault_path="$2"
 
-    echo "vault-${environment}-${os_username}-${os_region_name}"
+    uuencode -m "$file_path" /dev/stdout | vault write "$vault_path" value=-
 }
 
 setup_vault(){

--- a/bin/secrets/metadata.sh
+++ b/bin/secrets/metadata.sh
@@ -10,7 +10,10 @@ nodes_map["secret/jenkins/config/"]="$master"
 paths_map["secret/jenkins/config/credentials.xml"]="/var/jenkins_home/credentials.xml"
 paths_map["secret/jenkins/config/org.jenkinsci.plugins.ghprb.GhprbTrigger.xml"]="/var/jenkins_home/org.jenkinsci.plugins.ghprb.GhprbTrigger.xml"
 paths_map["secret/jenkins/config/secret.key"]="/var/jenkins_home/secret.key"
+
+nodes_map["secret/jenkins/config/secrets/"]="$master"
 paths_map["secret/jenkins/config/secrets/master.key"]="/var/jenkins_home/secrets/master.key"
+paths_map["secret/jenkins/config/secrets/hudson.util.Secret"]="/var/jenkins_home/secrets/hudson.util.Secret"
 paths_map["secret/jenkins/config/users/admin/config.xml"]="/var/jenkins_home/users/admin/config.xml"
 
 nodes_map["secret/jenkins/tests/gpg/"]="$slaves"

--- a/bin/secrets/restore.sh
+++ b/bin/secrets/restore.sh
@@ -28,7 +28,7 @@ restore_dir(){
         for completefile in $(find "$dir" -maxdepth 1 -type f); do
             echo "writing file $file"
             file=$(strip_base_dir "$completefile")
-            vault write "secret$file" value=@"$completefile"
+            vault_write_from_file "$completefile" "secret$file"
         done
     done
 }


### PR DESCRIPTION
With these changes all the values (binary or not) are stored in vault encoded with `uuencode` (base64). The `backup` and `restore` scripts take care of encoding/decoding.