### PR TITLE
set SNAP_REEXEC=0 in autopkgtest

### DIFF
--- a/containers/jenkins-master/config/jobs/github-snappy-autopkgtest-cloud/config.xml
+++ b/containers/jenkins-master/config/jobs/github-snappy-autopkgtest-cloud/config.xml
@@ -126,7 +126,7 @@ openstack keypair create --public-key /home/jenkins-slave/.ssh/id_rsa.pub $BUILD
 trap "openstack keypair delete $BUILD_TAG" EXIT
 
 rm -rf $WORKSPACE/adt-run-output
-adt-run .// --setup-commands setup-testbed -o $WORKSPACE/adt-run-output --- ssh -d -l ubuntu -o='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' -s nova -- -d --flavor autopkgtest --image 'ubuntu/ubuntu-xenial-16.04-amd64-server-*' --keyname $BUILD_TAG --security-groups ssh -e 'http_proxy=http://squid.internal:3128' -e 'https_proxy=http://squid.internal:3128' -e 'no_proxy=127.0.0.1,127.0.1.1,localhost,localdomain,novalocal,internal,archive.ubuntu.com,security.ubuntu.com,ddebs.ubuntu.com,ppa.launchpad.net'
+adt-run .// --setup-commands setup-testbed -o $WORKSPACE/adt-run-output --- ssh -d -l ubuntu -o='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' -s nova -- -d --flavor autopkgtest --image 'ubuntu/ubuntu-xenial-16.04-amd64-server-*' --keyname $BUILD_TAG --security-groups ssh -e 'http_proxy=http://squid.internal:3128' -e 'https_proxy=http://squid.internal:3128' -e 'no_proxy=127.0.0.1,127.0.1.1,localhost,localdomain,novalocal,internal,archive.ubuntu.com,security.ubuntu.com,ddebs.ubuntu.com,ppa.launchpad.net' -e SNAP_REEXEC=0
 ]]></command>
     </hudson.tasks.Shell>
   </builders>


### PR DESCRIPTION
Soon both `snap` and `snapd` will re-exec themselves to run from inside the core snap if it is installed. This'll break tests unless the environ is set up to avoid it.