### PR TITLE
Run the scalingstack cleanup only in xenial

### DIFF
--- a/containers/jenkins-master/config/jobs/scalingstack-cleanup/config.xml
+++ b/containers/jenkins-master/config/jobs/scalingstack-cleanup/config.xml
@@ -16,7 +16,8 @@
     </com.sonyericsson.rebuild.RebuildSettings>
   </properties>
   <scm class="hudson.scm.NullSCM"/>
-  <canRoam>true</canRoam>
+  <assignedNode>xenial</assignedNode>
+  <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>


### PR DESCRIPTION
The openstack commands that we are running have some flags that are not present in vivid.