### PR TITLE
Get the newest version of the distribution available for autopkgtest

### DIFF
--- a/containers/jenkins-master/config/jobs/github-snapcraft-autopkgtest-cloud/config.xml
+++ b/containers/jenkins-master/config/jobs/github-snapcraft-autopkgtest-cloud/config.xml
@@ -29,7 +29,7 @@
         <hudson.model.StringParameterDefinition>
           <name>distribution</name>
           <description></description>
-          <defaultValue>xenial-16.04</defaultValue>
+          <defaultValue>xenial</defaultValue>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
@@ -119,7 +119,7 @@ openstack keypair create --public-key /home/jenkins-slave/.ssh/id_rsa.pub $BUILD
 trap "openstack keypair delete $BUILD_TAG" EXIT
 
 rm -rf $WORKSPACE/adt-run-output
-adt-run .// --setup-commands setup-testbed -o $WORKSPACE/adt-run-output --- ssh -d -l ubuntu -o='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' -s nova -- -d --flavor autopkgtest --image "ubuntu/ubuntu-${distribution}-amd64-server-*" --keyname $BUILD_TAG --security-groups ssh -e 'http_proxy=http://squid.internal:3128' -e 'https_proxy=http://squid.internal:3128' -e 'no_proxy=127.0.0.1,127.0.1.1,localhost,localdomain,novalocal,internal,archive.ubuntu.com,security.ubuntu.com,ddebs.ubuntu.com,ppa.launchpad.net'
+adt-run .// --setup-commands setup-testbed -o $WORKSPACE/adt-run-output --- ssh -d -l ubuntu -o='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' -s nova -- -d --flavor autopkgtest --image "ubuntu/ubuntu-${distribution}.*-amd64-server-*" --keyname $BUILD_TAG --security-groups ssh -e 'http_proxy=http://squid.internal:3128' -e 'https_proxy=http://squid.internal:3128' -e 'no_proxy=127.0.0.1,127.0.1.1,localhost,localdomain,novalocal,internal,archive.ubuntu.com,security.ubuntu.com,ddebs.ubuntu.com,ppa.launchpad.net'
 </command>
     </hudson.tasks.Shell>
   </builders>

--- a/containers/jenkins-master/config/jobs/github-snappy-autopkgtest-cloud/config.xml
+++ b/containers/jenkins-master/config/jobs/github-snappy-autopkgtest-cloud/config.xml
@@ -29,7 +29,7 @@
         <hudson.model.StringParameterDefinition>
           <name>distribution</name>
           <description></description>
-          <defaultValue>xenial-16.04</defaultValue>
+          <defaultValue>xenial</defaultValue>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
@@ -131,7 +131,7 @@ openstack keypair create --public-key /home/jenkins-slave/.ssh/id_rsa.pub $BUILD
 trap "openstack keypair delete $BUILD_TAG" EXIT
 
 rm -rf $WORKSPACE/adt-run-output
-adt-run .// --setup-commands setup-testbed -o $WORKSPACE/adt-run-output --- ssh -d -l ubuntu -o='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' -s nova -- -d --flavor autopkgtest --image ubuntu/ubuntu-${distribution}-amd64-server-* --keyname $BUILD_TAG --security-groups ssh -e 'http_proxy=http://squid.internal:3128' -e 'https_proxy=http://squid.internal:3128' -e 'no_proxy=127.0.0.1,127.0.1.1,localhost,localdomain,novalocal,internal,archive.ubuntu.com,security.ubuntu.com,ddebs.ubuntu.com,ppa.launchpad.net' -e SNAP_REEXEC=0
+adt-run .// --setup-commands setup-testbed -o $WORKSPACE/adt-run-output --- ssh -d -l ubuntu -o='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no' -s nova -- -d --flavor autopkgtest --image "ubuntu/ubuntu-${distribution}.*-amd64-server-*" --keyname $BUILD_TAG --security-groups ssh -e 'http_proxy=http://squid.internal:3128' -e 'https_proxy=http://squid.internal:3128' -e 'no_proxy=127.0.0.1,127.0.1.1,localhost,localdomain,novalocal,internal,archive.ubuntu.com,security.ubuntu.com,ddebs.ubuntu.com,ppa.launchpad.net' -e SNAP_REEXEC=0
 ]]></command>
     </hudson.tasks.Shell>
   </builders>


### PR DESCRIPTION
With this we will use the daily image, if available.
The daily is only available in lgw01, but I tested that the other regions take the 16.04 image alright.